### PR TITLE
Switch to `asfoldable`; implement `iterate` fallback

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -54,12 +54,14 @@ function Base.iterate(k::Kernel)
     x, s = res
     x, (foldable, s)
 end
+
 function Base.iterate(::Kernel, (foldable, s))
     res = iterate(foldable, s)
     isnothing(res) && return res
     x, s = res
     x, (foldable, s)
 end
+
 Base.IteratorSize(::Type{<:Kernel}) = Base.SizeUnknown()
 
 align(kernel::Kernel, cell::Cell) = @set kernel.origin = (cell.x, cell.y)


### PR DESCRIPTION
`::Kernel` is now iterable, using Transducers.jl's fallback `iterate` methods for a transducer. It's slower than folding though, so I kept your `Base.map`, `Base.filter` and `Base.count` methods.